### PR TITLE
Envoi de messages multi-lignes par le bot

### DIFF
--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -18,7 +18,8 @@ class YammerAdapter extends Adapter
 
  prepare_string: (str, callback) ->
      text = str
-     yamsText = str.split('\n')
+ #   yamsText = str.split('\')
+     yamsText = [str]
      yamsText.forEach (yamText) => 
         callback yamText
 


### PR DESCRIPTION
Proposition pour traiter les messages multi-lignes: Désactive l'envoi d'1 message par ligne, pour les messages du robot qui en contiennent plusieurs.
