### PR TITLE
Fix for issue #7: hubot replies should be to the original message

### DIFF
--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -95,7 +95,7 @@ class YammerRealtime extends EventEmitter
       params =
          body          : yamText
          group_id      : group_id
-         replied_to_id : user.thread_id
+         replied_to_id : if user then user.thread_id else null
          og_url        : og_url
          og_fetch      : og_fetch
          og_image      : og_image


### PR DESCRIPTION
Add some more context data to the user object, such that when replying we can add the conversation id to the message and this will show up as a reply to message, and not a new message
