### PR TITLE
Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-yammer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Aurélien Thieriot",
   "keywords": [
     "github hubot yammer adapter"

--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -46,13 +46,13 @@ class YammerAdapter extends Adapter
           if self_id == sender_id && !bot.reply_self
             me = @robot.name
             @robot.logger.debug "Skipping a message from self."
-            else
-              user =
-                name: user_name
-                id: sender_id
-                thread_id: thread_id
-              self.receive new TextMessage user, text
-      @robot.logger.error "received error: #{err}" if err
+          else
+            user =
+              name: user_name
+              id: sender_id
+              thread_id: thread_id
+            self.receive new TextMessage user, text
+      @robot.logger.error "Received a error: #{err}" if err
 
     @bot = bot
     @emit 'connected'
@@ -134,6 +134,6 @@ class YammerRealtime extends EventEmitter
       @robot.logger.info "Allowed groups: " + groups
       @robot.logger.info "Group IDs: " + result
 
-      throw new Error "No groups selected or ID resolution failed." if no result.length
+      throw new Error "No groups selected or ID resolution failed." if not result.length
 
     result

--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -114,7 +114,7 @@ class YammerRealtime extends EventEmitter
       @robot.logger.error "Yammer error: #{err} #{data}" if err
       @robot.logger.info "Message creation status #{res.statusCode}"
 
- resolving_groups_ids: (groups) ->
+  resolving_groups_ids: (groups) ->
     #TODO: Need to make this function using a callback
     #      I don't think this will really work with too many groups
     result = []

--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -32,7 +32,7 @@ class YammerAdapter extends Adapter
       # for debugging use:  HUBOT_YAMMER_REPLY_SELF=1
       # bin/hubot -n bot -a yammer
 
-    bot = new YammerRealtime options, robot
+    bot = new YammerRealtime options, @robot
     bot.listen (err, data) ->
       user_name = (reference.name for reference in data.references when reference.type is "user")
       self_id = data.meta.current_user_id

--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -1,148 +1,139 @@
-Robot   = require('hubot').Robot
-Adapter = require('hubot').Adapter
+Robot       = require('hubot').Robot
+Adapter     = require('hubot').Adapter
 TextMessage = require('hubot').TextMessage
 
-HTTPS        = require 'https'
+HTTPS        = require('https')
 EventEmitter = require('events').EventEmitter
 Yammer       = require('yammer').Yammer
 
 class YammerAdapter extends Adapter
- send: (envelope, strings...) ->
-   user = if envelope.user then envelope.user else envelope
-   strings.forEach (str) =>
+  message = (envelope, strings...) ->
+    user = envelope.user or envelope
+    strings.forEach (str) =>
       @prepare_string str, (yamText) =>
-         @bot.send user,yamText
+        @bot.send user, yamText
 
- reply: (envelope, strings...) ->
-   user = if envelope.user then envelope.user else envelope
-   strings.forEach (str) =>
-      @prepare_string str,(yamText) =>
-         @bot.reply user,yamText
+  send: message
+  reply: message
 
- prepare_string: (str, callback) ->
-     text = str
-     yamsText = [str]
-     yamsText.forEach (yamText) =>
-        callback yamText
+  prepare_string: (str, callback) ->
+    text = str
+    yamsText = [str]
+    yamsText.forEach (yamText) =>
+      callback yamText
 
- run: ->
-   self = @
-   options =
-    access_token: process.env.HUBOT_YAMMER_ACCESS_TOKEN
-    groups      : process.env.HUBOT_YAMMER_GROUPS or "hubot"
-    reply_self  : process.env.HUBOT_YAMMER_REPLY_SELF # for debugging use:  HUBOT_YAMMER_REPLY_SELF=1 bin/hubot -n bot -a yammer
-   bot = new YammerRealtime(options)
+  run: ->
+    self = @
 
-   bot.listen (err, data) ->
+    options =
+      access_token: process.env.HUBOT_YAMMER_ACCESS_TOKEN
+      groups:       process.env.HUBOT_YAMMER_GROUPS or "hubot"
+      reply_self:   process.env.HUBOT_YAMMER_REPLY_SELF
+      # for debugging use:  HUBOT_YAMMER_REPLY_SELF=1
+      # bin/hubot -n bot -a yammer
+
+    bot = new YammerRealtime options, robot
+    bot.listen (err, data) ->
       user_name = (reference.name for reference in data.references when reference.type is "user")
       self_id = data.meta.current_user_id
       data.messages.forEach (message) =>
-         # checking message is received from valid group
-         if message.group_id in bot.groups_ids
-             thread_id = message.thread_id
-             sender_id = message.sender_id
-             text = message.body.plain
-             console.log "received #{text} from #{user_name} (thread_id: #{thread_id}, sender_id: #{sender_id})"
-             if self_id == sender_id && !bot.reply_self
-               me = self.robot.name
-               console.log "#{me} does not reply himself, #{me} not crazy nor desperate"
-             else
-               user =
-                 name: user_name
-                 id: sender_id
-                 thread_id: thread_id
-               self.receive new TextMessage user, text
-      if err
-         console.log "received error: #{err}"
+        if message.group_id in bot.groups_ids
+          thread_id = message.thread_id
+          sender_id = message.sender_id
+          text = message.body.plain
+          @robot.logger.debug "A message from #{user_name}: #{text}
+                               (thread_id: #{thread_id}, sender_id: #{sender_id})."
+          if self_id == sender_id && !bot.reply_self
+            me = @robot.name
+            @robot.logger.debug "Skipping a message from self."
+            else
+              user =
+                name: user_name
+                id: sender_id
+                thread_id: thread_id
+              self.receive new TextMessage user, text
+      @robot.logger.error "received error: #{err}" if err
 
-   @bot = bot
-   self.emit 'connected'
+    @bot = bot
+    @emit 'connected'
 
 exports.use = (robot) ->
- new YammerAdapter robot
+  new YammerAdapter robot
 
 class YammerRealtime extends EventEmitter
- self = @
- groups_ids = []
- constructor: (options) ->
+  constructor: (options, robot) ->
     if options.access_token?
-      @yammer = new Yammer
-         access_token: options.access_token
-
+      @yammer = new Yammer(access_token: options.access_token)
       @groups_ids = @resolving_groups_ids options.groups
       @reply_self = options.reply_self
     else
       throw new Error "Not enough parameters provided. I need an access token"
 
- ## Yammer API call methods
- listen: (callback) ->
-   @yammer.realtime.messages (err, data) ->
-     if 'data' of data
-       callback err, data.data
+  ## Yammer API call methods
+  listen: (callback) ->
+    @yammer.realtime.messages (err, data) ->
+      callback err, data.data if 'data' of data
 
- send: (user, yamText) ->
-   if user && user.thread_id
-     @reply user, yamText
-   else
-     #TODO: Adapt to flood overflow
-     groups_ids.forEach (group_id) =>
-       params =
-         body          : yamText
-         group_id      : group_id
+  send: (user, yamText) ->
+    if user && user.thread_id
+      @reply user, yamText
+    else
+      #TODO: Adapt to flood overflow
+      groups_ids.forEach (group_id) =>
+        params =
+          body:     yamText
+          group_id: group_id
 
-       console.log "send message to group #{params.group_id} with text #{params.body}"
-       @create_message params
+      @robot.logger.info "Sent a message to group #{params.group_id}: #{params.body}"
+      @create_message params
 
- reply: (user, yamText) ->
-   if user && user.thread_id
-     params =
-       body          : yamText
-       replied_to_id : user.thread_id
+  reply: (user, yamText) ->
+    if user && user.thread_id
+      params =
+        body:          yamText
+        replied_to_id: user.thread_id
 
-     console.log "reply message to #{user.name} with text #{params.body}"
-     @create_message params
+      @robot.logger.info "Replied to #{user.name}: #{params.body}"
+      @create_message params
 
- ## Utility methods
- create_message: (params) ->
-   # Build opengraph urls
-   urls = params.body.match /\bhttps?:\/\/[^ ]+/
-   if urls
-     og_url = urls[0]
-     params['og_url'] = og_url
-     if og_url.match /.*\.(gif|png|jpg|jpeg)/i
-       # Try to identify images
-       params['og_image'] = og_url
-     else
-       # let yammer do its best...
-       params['og_fetch'] = true
+  ## Utility methods
+  create_message: (params) ->
+    # Build opengraph urls
+    urls = params.body.match /\bhttps?:\/\/[^ ]+/
+    if urls
+      og_url = urls[0]
+      params['og_url'] = og_url
+      if og_url.match /.*\.(gif|png|jpg|jpeg)/i
+        # Try to identify images
+        params['og_image'] = og_url
+      else
+        # let yammer do its best...
+        params['og_fetch'] = true
 
-   @yammer.createMessage params, (err, data, res) ->
-      if err
-         console.log "yammer send error: #{err} #{data}"
-
-      console.log "Message creation status #{res.statusCode}"
+    @yammer.createMessage params, (err, data, res) ->
+      @robot.logger.error "Yammer error: #{err} #{data}" if err
+      @robot.logger.info "Message creation status #{res.statusCode}"
 
  resolving_groups_ids: (groups) ->
-   #TODO: Need to make this function using a callback
-   #      I don't thing this will really work with too many groups
-   result = []
-   params =
-     qs:
-       mine: 1
+    #TODO: Need to make this function using a callback
+    #      I don't think this will really work with too many groups
+    result = []
+    params =
+      qs:
+        mine: 1
 
-   @yammer.groups params, (err, data) ->
+    @yammer.groups params, (err, data) ->
       if err
-         console.log "yammer groups error: #{err} #{data}"
+        @robot.logger.error "Groups error (#{err}): #{data}"
       else
-         data.forEach (existing_group) =>
-            groups.split(",").forEach (group) =>
-               if group.toString().toLowerCase() is existing_group.name.toString().toLowerCase()
-                  result.push existing_group.id
+        data.forEach (existing_group) =>
+          groups.split(",").forEach (group) =>
+            if group.toString().toLowerCase() is existing_group.name.toString().toLowerCase()
+              result.push existing_group.id
 
-      console.log "groups list : " + groups
-      console.log "groups_ids list : " + result
+      @robot.logger.info "Allowed groups: " + groups
+      @robot.logger.info "Group IDs: " + result
 
-      if result.length is 0
-         throw new Error "No group registered or an error occured to resolve IDs."
+      throw new Error "No groups selected or ID resolution failed." if no result.length
 
-   result
+    result


### PR DESCRIPTION
Minor cleanup and refactoring, mainly replacing `console.log` with Hubot's `robot.logger`. Adapter's logs now behave as native Hubot's logs would: timestamped, categorized and controlled by logging settings. Fixed some slight spacing and formatting issues, too.

I'll test this PR some more before merging.

@athieriot: I bumped the version to 0.2.1, but nothing really changed except for logging, so there's no rush with publishing, don't worry!