### PR TITLE
Provide NPM deployment facility which leverage Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
-  - "4.1"
+  - '4.1'
+deploy:
+  provider: npm
+  email: a.thieriot@gmail.com
+  api_key:
+    secure: P6nY+WYtprS/0YtOEnJvYp63O49shObaV/L5Df51nRLZG7bVVJIuhq/v7GEfRMnBfvNIXCvUt3eOhT6Xnihyk0k6PBHZqeuo15KZneDZuaDSoIwRHhe3JFvGPj60LLpz6FyXMV3mPOVLwxjA9JuZFi+PxCXSvznko4qTHgOAXpM=
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '4.1'
+  - "4.1"
 deploy:
   provider: npm
   email: a.thieriot@gmail.com

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,67 @@
+var gulp = require('gulp'),
+    inquirer = require("inquirer"), 
+    git = require('gulp-git'),
+    bump = require('gulp-bump'),
+    filter = require('gulp-filter'),
+    tag_version = require('gulp-tag-version');
+ 
+var requested = {};
+
+gulp.task('ask', function (cb) {
+    inquirer.prompt([{
+      type: "list",
+      message: "What kind of release would you like to do?",
+      name: "type",
+      choices: ['patch', 'minor', 'major', 'custom']
+    }, {
+      type: "input",
+      name: "version",
+      message: "What version number then?",
+      when: function (answers) {
+        return answers.type && answers.type == 'custom';
+      },
+      validate: function( value ) {
+        var pass = value.match(/v?\d+\.\d+\.\d+(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?/ig);
+        return pass ? true : "Please enter a valid version number";
+      }
+    }], function(answers) {
+      if (answers.version) {
+        requested = { version: answers.version };
+      } else {
+        requested = { type: answers.type };
+      }
+
+      cb();
+    });
+});
+
+/**
+ * Bumping version number and tagging the repository with it.
+ * Please read http://semver.org/
+ *
+ * Use command:
+ *
+ *     gulp release
+ *
+ * To be prompted to give a version number to bump to 
+ *
+ *     patch           # makes 0.1.0 → 0.1.1
+ *     minor           # makes 0.1.1 → 0.2.0
+ *     major           # makes 0.2.1 → 1.0.0
+ *     custom x.x.x    # makes x.x.x → x.x.x
+ *
+ * Pushing a Tag will trigger Travis CI to release to NPM
+ */
+gulp.task('release', ['ask'], function () { 
+  return gulp.src(['./package.json'])
+      // bump the version number
+      .pipe(bump(requested))
+      // save it back to filesystem 
+      .pipe(gulp.dest('./'))
+      // commit the changed version number 
+      .pipe(git.commit('Bumps package version'))
+      // read only one file to get the version number 
+      .pipe(filter('package.json'))
+      // **tag it in the repository** 
+      .pipe(tag_version());
+})

--- a/package.json
+++ b/package.json
@@ -22,7 +22,13 @@
     "yammer": "0.1.0"
   },
   "devDependencies": {
-    "coffee-script": "1.1.3"
+    "coffee-script": "1.1.3",
+    "gulp": "^3.9.0",
+    "gulp-bump": "^1.0.0",
+    "gulp-filter": "^3.0.1",
+    "gulp-git": "^1.7.0",
+    "gulp-tag-version": "^1.3.0",
+    "inquirer": "^0.11.4"
   },
   "main": "./src/yammer",
   "engine": "node > 0.6.0 < 0.7.0",


### PR DESCRIPTION
You've been ahead of me with your PR :p (https://github.com/StackStorm/docker-hubot/pull/9) but I prepared something that should be practical for both of us (I hope).

It probably won't work the first time but it's worth the try anyway.
In a nutshell, Travis CI is able to publish to NPM is behalf of somebody and you can configure it so it does it everytime someone is pushing a new Git tag.

So this Pull Request provide the relevant Travis CI step + a convenient ```gulp``` task to bump the version number. Running:

      gulp release

Will prompt you with a few choice of version increment strategy (minor, major, patch) or you can enter a manual number compatible with ```semver```. Then:

   - The __package.json__ is going to be updated
   - A new Git __commit__ created with that change inside
   - And finally, a Git __tag__ is created. 

Currently you have to push the tag manually (This can also be automated) but I figured this would be acceptable:

      git push --tags

I know it's not as nice for you as having direct access on NPM but it gives me some insurance over what repository is deployed on NPM at least.

And hopefully this gives you more freedom with the releases (Instead of using the master branch directly) and to be honest the gulp task is nice for me too :p