### PR TITLE
Removing unneeded dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,59 +4,41 @@
 
 ## Description
 
-This is the [Yammer](http://www.yammer.com) adapter for hubot that allows you to
-send a message to him with Yammer and he will happily reply the same way.
+This is the [Yammer](http://www.yammer.com) adapter for [Hubot](https://github.com/github/hubot) that allows communication in Yammer public groups.
 
 ## Installation
 
 * Install dependencies with `npm install`
-* Run hubot with `bin/hubot -a yammer -n the_name_of_the_yammer_bot_account`
+* Set environment variables (below)
+* Run hubot with `bin/hubot -a yammer -n name`
 
-## Yammer side
+## Yammer account and token
 
 * Create a new account for your bot in your Yammer domain
-* Create a new application for hubot (see bellow)
-* You'll need to create at least one group in wich hubot will talk. By default, this group is "hubot" but you can change him
-
-### Note if running on Heroku
-
-You will need to change the process type from `app` to `web` in the `Procfile`.
+* Sign in as the new user
+* Register an API application at `https://www.yammer.com/client_applications`
+* Take note of the token you're given (copy it to `HUBOT_YAMMER_ACCESS_TOKEN`)
+* Currently you also need to create at least one public group for your bot
 
 ## Usage
 
-You will need to set some environment variables to use this adapter.
+You will need to set environment variables to use this adapter:
 
 ### Heroku
 
     % heroku config:add HUBOT_YAMMER_ACCESS_TOKEN="access_token"
     % heroku config:add HUBOT_YAMMER_GROUPS="groups list"
 
+    You will also need to change the process type from `app` to `web` in the `Procfile`.
+
 ### Non-Heroku environment variables
 
     % export HUBOT_YAMMER_ACCESS_TOKEN="access_token"
     % export HUBOT_YAMMER_GROUPS="groups list"
 
-## How do you get your access token
-
-Here's how to get a valid Yammer OAuth2 token with the standard OAuth2 authorization flow.
-
-See [Yammer documentation](https://developer.yammer.com/api/oauth2.html) for more details.
-
-* Register a new application on Yammer at `https://www.yammer.com/client_applications`. Leave the callback URLs empty
-* Take notes of your `consumer_key` and `consumer_secret`
-* Make a new bot user on Yammer.
-* Sign in as the new bot user on Yammer
-* Go to `https://www.yammer.com/dialog/oauth?client_id=<consumer_key>`
-* There's an authorization dialog. Authorize the app
-* Look at the URL bar and there's a `code=<CODE>` query parameter in there, copy that
-* `curl https://www.yammer.com/oauth2/access_token?code=<CODE>&client_id=<consumer_key>&client_secret=<consumer_secret>`
-* you'll get a big JSON that contains `access_token`
-
-Now set the token to `HUBOT_YAMMER_ACCESSTOKEN`.
-
 ## Contribute
 
-Just send pull request if needed or fill an issue!
+Just send a pull request if needed or file an issue!
 
 ## Copyright
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "url": "git://github.com/athieriot/hubot-yammer.git"
   },
   "dependencies": {
-    "hubot": ">=2.3.0",
-    "request": "2.9.3",
     "yammer": "0.1.0"
   },
   "devDependencies": {
@@ -28,7 +26,8 @@
     "gulp-filter": "^3.0.1",
     "gulp-git": "^1.7.0",
     "gulp-tag-version": "^1.3.0",
-    "inquirer": "^0.11.4"
+    "inquirer": "^0.11.4",
+    "hubot": ">=2.3.0"
   },
   "main": "./src/yammer",
   "engine": "node > 0.6.0 < 0.7.0",


### PR DESCRIPTION
1. `hubot-yammer` doesn’t “depend” on `hubot` in the package.json sense, it’s the other way around. :) 
It’s a dev-dependency at best (`hubot-slack` lists it in dev, `hubot-hipchat` doesn’t list it at all), and installing inside a docker container with a hubot dependency is suboptimal because it’ll fetch hubot the second time. 

2. I couldn’t find any reference to `request` in the code, so I’m removing it. @athieriot: need your input here, you might know something I don’t. :)