### PR TITLE
Use Group Full Name when searching for ID

### DIFF
--- a/src/yammer.coffee
+++ b/src/yammer.coffee
@@ -130,7 +130,7 @@ class YammerRealtime extends EventEmitter
       else
         data.forEach (existing_group) =>
           groups.split(",").forEach (group) =>
-            if group.toString().toLowerCase() is existing_group.name.toString().toLowerCase()
+            if group.toString().toLowerCase() is existing_group.full_name.toString().toLowerCase()
               result.push existing_group.id
 
       @robot.logger.info "Allowed groups: " + groups


### PR DESCRIPTION
It seems that the short name is stripped of any underscore or special
character so it make sense to search a group ID by the full name (Which
is most likely what a Yammer user will use in the configuration)